### PR TITLE
Add some missing perldoc pages from 5.22.0

### DIFF
--- a/lib/Perldoc/Section.pm
+++ b/lib/Perldoc/Section.pm
@@ -19,10 +19,12 @@ our @section_data = (
     id    => 'tutorials',
     name  => 'Tutorials',
     pages => [qw/perlreftut perldsc perllol perlrequick
-                 perlretut perlboot perltoot perltooc perlbot
+                 perlretut perlboot perltoot perltooc perlbot perlootut
                  perlstyle perlcheat perltrap perldebtut
                  perlopentut perlpacktut perlthrtut perlothrtut
-                 perlxstut perlunitut perlpragma/]
+                 perlxstut perlunitut perlpragma
+                 perlpodstyle perlsource perlgit perlhacktips perlhacktut
+                 /]
   },
   {
     id        => 'faq',
@@ -39,18 +41,21 @@ our @section_data = (
                  perllexwarn perldebug perlvar perlre
                  perlreref perlrebackslash perlrecharclass perlref perlform perlobj perltie
                  perldbmfilter perlipc perlfork perlnumber
-                 perlperf perlport perllocale perluniintro perlunicode perluniprops
+                 perlperf perlport perllocale perluniintro perlunicode perluniprops perlunicook perlunifaq
                  perlebcdic perlsec perlmod perlmodlib
                  perlmodstyle perlmodinstall perlnewmod
                  perlcompile perlfilter perlglossary CORE
+                 perlexperiment
                  /]
   },
   {
     id    => 'internals',
     name  => 'Internals and C language interface',
-    pages => [qw/perlembed perldebguts perlxs perlxstut perlrepository
+    pages => [qw/perldtrace perlembed perldebguts perlxs perlxstut perlrepository
                  perlclib perlguts perlcall perlapi perlintern perlmroapi
-                 perliol perlapio perlhack perlreguts perlreapi perlpolicy/]
+                 perliol perlapio perlhack perlreguts perlreapi perlpolicy
+                 perlinterp  perlxstypemap
+            /]
   },
   { 
     id        => 'history',
@@ -71,12 +76,12 @@ our @section_data = (
   {
     id    => 'platforms',
     name  => 'Platform specific',
-    pages => [qw/perlaix perlamiga perlapollo perlbeos perlbs2000
+    pages => [qw/perlaix perlamiga perlandroid perlapollo perlbeos perlbs2000
                  perlce perlcygwin perldgux perldos perlepoc
                  perlfreebsd perlhaiku perlhpux perlhurd perlirix perllinux
                  perlmachten perlmacos perlmacosx perlmint perlmpeix
                  perlnetware perlopenbsd perlos2 perlos390 perlos400
-                 perlplan9 perlqnx perlriscos perlsolaris perlsymbian perltru64 perluts
+                 perlplan9 perlqnx perlriscos perlsolaris perlsymbian perlsynology perltru64 perluts
                  perlvmesa perlvms perlvos perlwin32/]
   },
   { 


### PR DESCRIPTION
There's some pages in perl5.22.0 that aren't listed in Perldoc::Section. I suspect this will be an incomplete list: my quick hack to generate this list used:

```
perl -Ilib -E'use Perldoc::Section; my %seen = map {; $_ => 1 } map @{$_->{pages}}, @Perldoc::Section::section_data; say for keys %seen' | sort 
```

then compared against

```
for i in $(find ~/perl5/perlbrew/perls/perl-5.22.0/lib/5.22.0/ -name "perl*.pod"); do basename $i; done | sort > modules.lst
```

using comm(1):

```
comm -13 sections.lst modules.lst > missing.lst
```

this is probably something that could be automated, although there's a few false positives (perl_delta, perltw/perljp, perlfaq_).

A second issue that this doesn't resolve: the perldoc.perl.org pages do not have some of the core modules, such as IO::Socket::IP. This would require using the correct Perl version when running the build_.pl scripts, I suspect pre-5.18 was used. Since modules can be added or removed, I think each build-_.pl run needs to use a perlbrew (or equivalent) clean install for the relevant version, rather than trying to run them all from a single perl install? 
